### PR TITLE
Support cache parameter: minutes.

### DIFF
--- a/src/Gchaincl/LaravelFragmentCaching/Factory.php
+++ b/src/Gchaincl/LaravelFragmentCaching/Factory.php
@@ -2,7 +2,7 @@
 
 class Factory extends \Illuminate\View\Factory {
 
-    public function cacheif($condition, $key, \Closure $closure)
+    public function cacheif($condition, $key, $minutes, \Closure $closure)
     {
         if ( ! $condition ) {
             return $closure();
@@ -17,7 +17,7 @@ class Factory extends \Illuminate\View\Factory {
             $closure();
             $content = ob_get_contents();
             ob_end_clean();
-            $cache->forever($key, $content);
+            $cache->put($key, $content, $minutes);
             $log->debug('writing cache', [$key]);
         } else {
             $log->debug('reading cache', [$key]);
@@ -26,9 +26,9 @@ class Factory extends \Illuminate\View\Factory {
         return $content;
     }
 
-    public function cache($key, \Closure $closure)
+    public function cache($key, $minutes, \Closure $closure)
     {
-        return $this->cacheif(true, $key, $closure);
+        return $this->cacheif(true, $key, $minutes, $closure);
     }
 
 }

--- a/src/Gchaincl/LaravelFragmentCaching/ViewServiceProvider.php
+++ b/src/Gchaincl/LaravelFragmentCaching/ViewServiceProvider.php
@@ -33,7 +33,7 @@ class ViewServiceProvider extends \Illuminate\View\ViewServiceProvider
             ->getCompiler();
 
         $blade->extend(function($view, $compiler) {
-            $pattern = $compiler->createMatcher('cache');
+            $pattern = $compiler->createOpenMatcher('cache');
             return preg_replace($pattern, '$1' . $this->cacheTemplate(), $view);
         });
 
@@ -53,7 +53,7 @@ class ViewServiceProvider extends \Illuminate\View\ViewServiceProvider
         return <<<'EOF'
 <?php
 $__fc_vars = get_defined_vars();
-echo $__env->cache($2, function() use($__fc_vars) {
+echo $__env->cache$2, function() use($__fc_vars) {
     extract($__fc_vars);
 
     // Cached Content goes below this


### PR DESCRIPTION
New usage:
`@cache('post', 60)`

To cache forever just pass `0`, it's how Laravel's `Cache::forever()` works.
